### PR TITLE
Fix Avalonia theme missing package

### DIFF
--- a/src/reverb/App.axaml
+++ b/src/reverb/App.axaml
@@ -2,6 +2,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="reverb.App">
   <Application.Styles>
-    <FluentTheme Mode="Light"/>
+    <FluentTheme/>
   </Application.Styles>
 </Application>

--- a/src/reverb/reverb.csproj
+++ b/src/reverb/reverb.csproj
@@ -9,5 +9,6 @@
     <PackageReference Include="Avalonia" Version="11.0.0" />
     <PackageReference Include="Avalonia.Desktop" Version="11.0.0" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- include `Avalonia.Themes.Fluent` package in the app project

## Testing
- `cmake -B build -S . && cmake --build build`
- ❌ `dotnet restore src/reverb/reverb.csproj` *(failed: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700de59b9c833087e663dd68d4023a