### PR TITLE
Add platform build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@
 build/
 bin/
 obj/
+dotnet-install.sh

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Free open source voice chat
    ```
 3. Publish the GUI for Linux:
    ```
-   dotnet publish src/reverb/reverb.csproj -c Release -r linux-x64 --self-contained false
+   dotnet publish client/reverb/reverb.csproj -c Release -r linux-x64 --self-contained false
    ```
 
 ### Windows
@@ -26,5 +26,14 @@ Free open source voice chat
    ```
 3. Publish the GUI for Windows:
    ```
-   dotnet publish src/reverb/reverb.csproj -c Release -r win-x64 --self-contained false
+   dotnet publish client/reverb/reverb.csproj -c Release -r win-x64 --self-contained false
    ```
+
+### Build scripts
+
+Instead of running the commands manually you can execute one of the provided build scripts:
+
+* **Linux:** `./build_linux.sh`
+* **Windows:** `build_windows.ps1`
+
+The scripts place all build artifacts into `output/linux/bin` or `output/windows/bin` respectively.

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR"
+
+OUTPUT_DIR="$ROOT_DIR/output/linux"
+BUILD_DIR="$OUTPUT_DIR/build"
+BIN_DIR="$OUTPUT_DIR/bin"
+
+mkdir -p "$BUILD_DIR" "$BIN_DIR"
+
+# Build native libraries
+cmake -B "$BUILD_DIR" -S "$ROOT_DIR" -DCMAKE_BUILD_TYPE=Release
+cmake --build "$BUILD_DIR" --config Release
+
+# Copy native libraries to bin directory
+find "$BUILD_DIR" -name '*.so' -exec cp {} "$BIN_DIR" \;
+
+# Publish the .NET GUI application
+DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet publish "$ROOT_DIR/client/reverb/reverb.csproj" \
+  -c Release -r linux-x64 --self-contained false -o "$BIN_DIR"
+
+echo "Build completed. Binaries are in $BIN_DIR"

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -1,0 +1,23 @@
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$RootDir = $ScriptDir
+
+$OutputDir = Join-Path $RootDir 'output/windows'
+$BuildDir = Join-Path $OutputDir 'build'
+$BinDir   = Join-Path $OutputDir 'bin'
+
+New-Item -ItemType Directory -Force -Path $BuildDir, $BinDir | Out-Null
+
+# Build native libraries
+cmake -B $BuildDir -S $RootDir -DCMAKE_BUILD_TYPE=Release
+cmake --build $BuildDir --config Release
+
+# Copy native libraries to bin directory
+Get-ChildItem -Path $BuildDir -Filter '*.dll' -Recurse | ForEach-Object { Copy-Item $_.FullName $BinDir }
+
+# Publish the .NET GUI application
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = '1'
+dotnet publish "$RootDir/client/reverb/reverb.csproj" -c Release -r win-x64 --self-contained false -o $BinDir
+
+Write-Host "Build completed. Binaries are in $BinDir"


### PR DESCRIPTION
## Summary
- add `build_linux.sh` and `build_windows.ps1`
- ignore `dotnet-install.sh`
- mention scripts in README and fix publish paths

## Testing
- `./build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_6870a3f7bf308330978413aafa557aab