### PR TITLE
Fix Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,5 +4,10 @@ project(reverb VERSION 0.1 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Export all symbols automatically when building shared libraries on Windows
+if(WIN32)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 add_subdirectory(client/libvoice)
 add_subdirectory(client/libchat)


### PR DESCRIPTION
## Summary
- export symbols automatically on Windows

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --config Release`
- `dotnet publish client/reverb/reverb.csproj -c Release -r linux-x64 --self-contained false`


------
https://chatgpt.com/codex/tasks/task_e_6870c1b3726c833080311eecbd0b7d06