### PR TITLE
Enable chat with nng

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project(reverb VERSION 0.1 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+find_package(nng REQUIRED CONFIG)
+find_package(Threads REQUIRED)
+
 add_subdirectory(client/libvoice)
 add_subdirectory(client/libchat)
 add_subdirectory(server)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,25 @@ project(reverb VERSION 0.1 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(nng REQUIRED CONFIG)
+include(FetchContent)
+
+find_package(nng QUIET CONFIG)
+if(NOT nng_FOUND)
+    message(STATUS "nng not found, fetching...")
+    FetchContent_Declare(
+        nng
+        GIT_REPOSITORY https://github.com/nanomsg/nng.git
+        GIT_TAG v1.7.1
+    )
+    set(NNG_TESTS OFF CACHE BOOL "" FORCE)
+    set(NNG_TOOLS OFF CACHE BOOL "" FORCE)
+    set(BUILD_SHARED_LIBS ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(nng)
+    if(TARGET nng AND NOT TARGET nng::nng)
+        add_library(nng::nng ALIAS nng)
+    endif()
+endif()
+
 find_package(Threads REQUIRED)
 
 add_subdirectory(client/libvoice)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Free open source voice chat
 
 ### Linux
 
-1. Install CMake, a C++ toolchain and the .NET 9.0 SDK. The repository includes `dotnet-install.sh` that can be used to install the required SDK.
+1. Install CMake, a C++ toolchain and the .NET 9.0 SDK. The repository includes `dotnet-install.sh` that can be used to install the required SDK. During configuration CMake will automatically download the [nng](https://github.com/nanomsg/nng) library.
 2. Build the native libraries and server:
    ```
    cmake -B build -S . -DCMAKE_BUILD_TYPE=Release

--- a/client/libchat/CMakeLists.txt
+++ b/client/libchat/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_library(chat SHARED chat.cpp)
 
 target_include_directories(chat PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(chat PUBLIC nng::nng Threads::Threads)

--- a/client/libchat/chat.cpp
+++ b/client/libchat/chat.cpp
@@ -1,9 +1,93 @@
 #include "chat.h"
 
+#include <nng/nng.h>
+#include <nng/protocol/pubsub0/sub.h>
+#include <nng/protocol/pipeline0/push.h>
+
+#include <atomic>
+#include <cstring>
+#include <thread>
+
 namespace chat {
-void dummy() {}
+
+constexpr const char* PUSH_ADDR = "tcp://127.0.0.1:6001";
+constexpr const char* SUB_ADDR  = "tcp://127.0.0.1:6002";
+
+static nng_socket pushSock;
+static nng_socket subSock;
+static std::thread recvThread;
+static std::atomic<bool> running{false};
+static message_callback callback = nullptr;
+
+static void recv_loop()
+{
+    while (running) {
+        char* msg = nullptr;
+        size_t size = 0;
+        int rv = nng_recv(subSock, &msg, &size, NNG_FLAG_ALLOC);
+        if (rv == 0) {
+            if (callback)
+                callback(msg);
+            nng_free(msg, size);
+        } else if (rv == NNG_ETIMEDOUT) {
+            continue;
+        }
+    }
 }
 
-extern "C" void chat_dummy() {
-    chat::dummy();
+bool start(message_callback cb)
+{
+    callback = cb;
+    int rv;
+    if ((rv = nng_push0_open(&pushSock)) != 0)
+        return false;
+    if ((rv = nng_sub0_open(&subSock)) != 0)
+        return false;
+    if ((rv = nng_setopt(subSock, NNG_OPT_SUB_SUBSCRIBE, "", 0)) != 0)
+        return false;
+    if ((rv = nng_dial(pushSock, PUSH_ADDR, nullptr, 0)) != 0)
+        return false;
+    if ((rv = nng_dial(subSock, SUB_ADDR, nullptr, 0)) != 0)
+        return false;
+
+    running = true;
+    recvThread = std::thread(recv_loop);
+    return true;
+}
+
+void publish(const char* message)
+{
+    if (!message)
+        return;
+    nng_send(pushSock, (void*)message, std::strlen(message) + 1, 0);
+}
+
+void stop()
+{
+    running = false;
+    nng_close(pushSock);
+    nng_close(subSock);
+    if (recvThread.joinable())
+        recvThread.join();
+}
+
+} // namespace chat
+
+extern "C" {
+
+bool chat_start(chat_message_callback cb)
+{
+    return chat::start(cb);
+}
+
+void chat_publish(const char* message)
+{
+    chat::publish(message);
+}
+
+void chat_stop()
+{
+    chat::stop();
+}
+
 }

--- a/client/libchat/chat.h
+++ b/client/libchat/chat.h
@@ -1,13 +1,25 @@
 #pragma once
 
+#include <stddef.h>
+
 namespace chat {
-void dummy();
+using message_callback = void(*)(const char*);
+
+bool start(message_callback cb);
+void publish(const char* message);
+void stop();
 }
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-void chat_dummy();
+
+typedef void(*chat_message_callback)(const char*);
+
+bool chat_start(chat_message_callback cb);
+void chat_publish(const char* message);
+void chat_stop();
+
 #ifdef __cplusplus
 }
 #endif

--- a/client/reverb/Program.cs
+++ b/client/reverb/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.ReactiveUI;
@@ -7,17 +8,33 @@ namespace reverb;
 
 public class Program
 {
+    private delegate void ChatCallback(IntPtr message);
+
     [DllImport("chat", CallingConvention = CallingConvention.Cdecl)]
-    private static extern void chat_dummy();
+    private static extern bool chat_start(ChatCallback cb);
+
+    [DllImport("chat", CallingConvention = CallingConvention.Cdecl)]
+    private static extern void chat_publish([MarshalAs(UnmanagedType.LPStr)] string message);
+
+    [DllImport("chat", CallingConvention = CallingConvention.Cdecl)]
+    private static extern void chat_stop();
 
     [DllImport("voice", CallingConvention = CallingConvention.Cdecl)]
     private static extern void voice_dummy();
 
     public static void Main(string[] args)
     {
-        chat_dummy();
+        chat_start(OnChatMessage);
+        chat_publish("Hello from client");
         voice_dummy();
         BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+        chat_stop();
+    }
+
+    private static void OnChatMessage(IntPtr msg)
+    {
+        string? text = Marshal.PtrToStringAnsi(msg);
+        Console.WriteLine($"[chat] {text}");
     }
 
     public static AppBuilder BuildAvaloniaApp()

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_executable(reverb-server main.cpp)
 
 target_include_directories(reverb-server PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(reverb-server PRIVATE nng::nng Threads::Threads)

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -1,6 +1,52 @@
 #include <iostream>
+#include <nng/nng.h>
+#include <nng/protocol/pubsub0/pub.h>
+#include <nng/protocol/pipeline0/pull.h>
 
-int main() {
+constexpr const char* PULL_ADDR = "tcp://127.0.0.1:6001";
+constexpr const char* PUB_ADDR  = "tcp://127.0.0.1:6002";
+
+int main()
+{
+    nng_socket pullSock;
+    nng_socket pubSock;
+    int rv;
+
+    if ((rv = nng_pull0_open(&pullSock)) != 0) {
+        std::cerr << "failed to open pull socket: " << nng_strerror(rv) << std::endl;
+        return 1;
+    }
+
+    if ((rv = nng_pub0_open(&pubSock)) != 0) {
+        std::cerr << "failed to open pub socket: " << nng_strerror(rv) << std::endl;
+        return 1;
+    }
+
+    if ((rv = nng_listen(pullSock, PULL_ADDR, nullptr, 0)) != 0) {
+        std::cerr << "failed to listen on " << PULL_ADDR << ": " << nng_strerror(rv) << std::endl;
+        return 1;
+    }
+
+    if ((rv = nng_listen(pubSock, PUB_ADDR, nullptr, 0)) != 0) {
+        std::cerr << "failed to listen on " << PUB_ADDR << ": " << nng_strerror(rv) << std::endl;
+        return 1;
+    }
+
     std::cout << "reverb server running" << std::endl;
+
+    while (true) {
+        char* msg = nullptr;
+        size_t size = 0;
+        if ((rv = nng_recv(pullSock, &msg, &size, NNG_FLAG_ALLOC)) == 0) {
+            nng_send(pubSock, msg, size, 0);
+            std::cout << "chat: " << msg << std::endl;
+            nng_free(msg, size);
+        } else {
+            std::cerr << "recv error: " << nng_strerror(rv) << std::endl;
+        }
+    }
+
+    nng_close(pullSock);
+    nng_close(pubSock);
     return 0;
 }


### PR DESCRIPTION
## Summary
- add nng dependency
- implement a basic chat library using nng
- update server to forward chat messages
- expose chat from C# client

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --config Release`
- `dotnet build client/reverb/reverb.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_687152d1cd3c8330b765f2263322dd5c