### PR TITLE
Add connection details to GUI

### DIFF
--- a/client/reverb/MainWindow.axaml
+++ b/client/reverb/MainWindow.axaml
@@ -6,10 +6,24 @@
     <StackPanel Margin="20" Spacing="5">
         <TextBlock Text="Welcome to reverb"/>
 
-        <TextBlock Text="Input device:"/>
+        <TextBlock Text="Server:" Margin="0,10,0,0"/>
+        <TextBox x:Name="ServerBox" Width="300"/>
+
+        <TextBlock Text="Port:" Margin="0,10,0,0"/>
+        <NumericUpDown x:Name="PortBox" Width="100" Minimum="1" Maximum="65535"/>
+
+        <TextBlock Text="User name:" Margin="0,10,0,0"/>
+        <TextBox x:Name="UserNameBox" Width="300"/>
+
+        <TextBlock Text="Input device:" Margin="0,10,0,0"/>
         <ComboBox x:Name="InputDeviceBox" Width="300"/>
 
         <TextBlock Text="Output device:" Margin="0,10,0,0"/>
         <ComboBox x:Name="OutputDeviceBox" Width="300"/>
+
+        <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,10,0,0">
+            <Button x:Name="ConnectButton" Content="Connect" Click="ConnectClicked" Width="80"/>
+            <Button x:Name="DisconnectButton" Content="Disconnect" Click="DisconnectClicked" Width="80" IsEnabled="False"/>
+        </StackPanel>
     </StackPanel>
 </Window>

--- a/client/reverb/MainWindow.axaml.cs
+++ b/client/reverb/MainWindow.axaml.cs
@@ -1,4 +1,6 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
+using System;
 
 namespace reverb;
 
@@ -21,5 +23,25 @@ public partial class MainWindow : Window
         OutputDeviceBox.ItemsSource = outputs;
         if (outputs.Length > 0)
             OutputDeviceBox.SelectedIndex = 0;
+    }
+
+    private void ConnectClicked(object? sender, RoutedEventArgs e)
+    {
+        ConnectButton.IsEnabled = false;
+        DisconnectButton.IsEnabled = true;
+
+        string server = ServerBox.Text ?? string.Empty;
+        ushort port = (ushort)(PortBox.Value ?? 0);
+        string user = UserNameBox.Text ?? string.Empty;
+
+        Console.WriteLine($"Connect: server={server} port={port} user={user}");
+    }
+
+    private void DisconnectClicked(object? sender, RoutedEventArgs e)
+    {
+        ConnectButton.IsEnabled = true;
+        DisconnectButton.IsEnabled = false;
+
+        Console.WriteLine("Disconnect");
     }
 }


### PR DESCRIPTION
## Summary
- extend `MainWindow.axaml` with Server, Port, and User name inputs
- add Connect and Disconnect buttons
- implement basic handlers for the new buttons

## Testing
- `dotnet build client/reverb/reverb.csproj -c Release`
- `dotnet test` *(fails: MSB1003, no test project)*

------
https://chatgpt.com/codex/tasks/task_e_6871536c1c20833081079d936d783178